### PR TITLE
fix(spawn): Handle early exit better

### DIFF
--- a/@tracerbench/protocol-connection/src/index.ts
+++ b/@tracerbench/protocol-connection/src/index.ts
@@ -2,6 +2,7 @@ import { AttachMessageTransport } from "@tracerbench/message-transport";
 import newAttachProtocolTransport, {
   DebugCallback,
 } from "@tracerbench/protocol-transport";
+import { RaceCancellation } from "race-cancellation";
 
 import { EventEmitter } from "../types";
 
@@ -14,9 +15,10 @@ export default function newProtocolConnection(
   attach: AttachMessageTransport,
   newEventEmitter: () => EventEmitter,
   debug: DebugCallback = () => void 0,
+  raceCancellation?: RaceCancellation,
 ) {
   return _newProtocolConnection(
-    newAttachProtocolTransport(attach, debug),
+    newAttachProtocolTransport(attach, debug, raceCancellation),
     newEventEmitter,
   );
 }

--- a/@tracerbench/protocol-connection/src/newProtocolConnection.ts
+++ b/@tracerbench/protocol-connection/src/newProtocolConnection.ts
@@ -110,7 +110,10 @@ function newProtocolConnection(
 
   return base;
 
-  async function attachToTarget(targetId: TargetID | { targetId: TargetID }) {
+  async function attachToTarget(
+    targetId: TargetID | { targetId: TargetID },
+    raceCancellation?: RaceCancellation,
+  ) {
     if (typeof targetId === "object" && targetId !== null) {
       targetId = targetId.targetId;
     }
@@ -122,6 +125,7 @@ function newProtocolConnection(
     const resp: Protocol.Target.AttachToTargetResponse = await send(
       "Target.attachToTarget",
       request,
+      raceCancellation,
     );
     return connection(resp);
   }
@@ -129,13 +133,14 @@ function newProtocolConnection(
   async function setAutoAttach(
     autoAttach: boolean,
     waitForDebuggerOnStart = false,
+    raceCancellation?: RaceCancellation,
   ) {
     const request: Protocol.Target.SetAutoAttachRequest = {
       autoAttach,
       flatten: true,
       waitForDebuggerOnStart,
     };
-    await send("Target.setAutoAttach", request);
+    await send("Target.setAutoAttach", request, raceCancellation);
   }
 
   function onEvent(event: string, params: any) {

--- a/@tracerbench/protocol-connection/types.d.ts
+++ b/@tracerbench/protocol-connection/types.d.ts
@@ -71,6 +71,7 @@ export interface ProtocolConnectionBase {
    */
   attachToTarget(
     targetId: TargetID | { targetId: TargetID },
+    raceCancellation?: RaceCancellation,
   ): Promise<SessionConnection>;
 
   /**
@@ -100,6 +101,7 @@ export interface ProtocolConnectionBase {
   setAutoAttach(
     autoAttach: boolean,
     waitForDebuggerOnStart?: boolean,
+    raceCancellation?: RaceCancellation,
   ): Promise<void>;
 
   /**
@@ -288,10 +290,10 @@ export type Event = keyof ProtocolMapping.Events | "error" | "detached";
 
 export type EventMapping = {
   [E in keyof ProtocolMapping.Events]: ProtocolMapping.Events[E] extends [
-    (infer T)?
+    (infer T)?,
   ]
     ? T
-    : never
+    : never;
 } & {
   error: Error;
 };
@@ -299,23 +301,23 @@ export type EventMapping = {
 export type RequestMapping = {
   [M in Method]: ProtocolMapping.Commands[M]["paramsType"] extends [(infer T)?]
     ? T
-    : never
+    : never;
 };
 
 export type ResponseMapping = {
-  [M in Method]: ProtocolMapping.Commands[M]["returnType"]
+  [M in Method]: ProtocolMapping.Commands[M]["returnType"];
 };
 
 export type VoidRequestMethod = {
   [M in Method]: ProtocolMapping.Commands[M]["paramsType"] extends []
     ? M
-    : never
+    : never;
 }[Method];
 
 export type MappedRequestMethod = {
   [M in Method]: ProtocolMapping.Commands[M]["paramsType"] extends [infer T]
     ? M
-    : never
+    : never;
 }[Method];
 
 export type MaybeMappedRequestMethod = Exclude<
@@ -326,7 +328,7 @@ export type MaybeMappedRequestMethod = Exclude<
 export type VoidResponseMethod = {
   [M in Method]: ProtocolMapping.Commands[M]["returnType"] extends void
     ? M
-    : never
+    : never;
 }[Method];
 
 export type MappedResponseMethod = Exclude<Method, VoidResponseMethod>;
@@ -344,7 +346,7 @@ export type VoidEvent =
   | {
       [E in keyof ProtocolMapping.Events]: ProtocolMapping.Events[E] extends []
         ? E
-        : never
+        : never;
     }[keyof ProtocolMapping.Events]
   | "detached";
 

--- a/@tracerbench/protocol-transport/src/index.ts
+++ b/@tracerbench/protocol-transport/src/index.ts
@@ -1,4 +1,5 @@
 import { AttachMessageTransport } from "@tracerbench/message-transport";
+import { RaceCancellation } from "race-cancellation";
 
 import { DebugCallback } from "../types";
 
@@ -8,9 +9,10 @@ import _newAttachProtocolTransport from "./newAttachProtocolTransport";
 export default function newAttachProtocolTransport<SessionId>(
   attach: AttachMessageTransport,
   debug: DebugCallback = () => void 0,
+  raceCancellation?: RaceCancellation,
 ) {
   return _newAttachProtocolTransport<SessionId>(
-    newAttachJsonRpcTransport(attach, debug),
+    newAttachJsonRpcTransport(attach, debug, raceCancellation),
   );
 }
 

--- a/@tracerbench/spawn-chrome/src/spawnChrome.ts
+++ b/@tracerbench/spawn-chrome/src/spawnChrome.ts
@@ -24,14 +24,14 @@ export default function spawnChrome(options?: Partial<SpawnOptions>): Chrome {
   const args = getArguments(userDataDir, canonicalized);
 
   const process = Object.assign(
-    spawn(chromeExecutable, args, "ignore", "pipe"),
+    spawn(chromeExecutable, args, canonicalized.stdio, "pipe"),
     {
       userDataDir,
     },
   );
 
   if (removeTmp !== undefined) {
-    process.on("exit", removeTmp);
+    process.once("exit", removeTmp);
   }
 
   return process;

--- a/@tracerbench/spawn/src/newProcessWithPipeMessageTransport.ts
+++ b/@tracerbench/spawn/src/newProcessWithPipeMessageTransport.ts
@@ -1,7 +1,11 @@
+import debug = require("debug");
+
 import { ProcessWithPipeMessageTransport } from "../types";
 
 import createPipeMessageTransport from "./newPipeMessageTransport";
 import newProcess from "./newProcess";
+
+const debugCallback = debug("@tracerbench/spawn");
 
 export default function newProcessWithPipeMessageTransport(
   child: import("execa").ExecaChildProcess,
@@ -9,7 +13,35 @@ export default function newProcessWithPipeMessageTransport(
   const process = newProcess(child);
   const [, , , writeStream, readStream] = streamsForPipe(child);
   return Object.assign(process, {
-    attach: createPipeMessageTransport(writeStream, readStream),
+    attach: createPipeMessageTransport((onRead, onReadEnd, onClose) => {
+      child.on("error", onClose);
+      child.on("exit", onClose);
+
+      readStream.on("data", onRead);
+      readStream.on("end", () => {
+        debugCallback("read pipe end");
+        onReadEnd();
+      });
+      readStream.on("error", error => {
+        debugCallback("read pipe error %O", error);
+      });
+
+      writeStream.on("close", () => {
+        debugCallback("write pipe close");
+        onClose();
+      });
+      writeStream.on("error", (error: Error | NodeJS.ErrnoException) => {
+        debugCallback("write pipe error %O", error);
+        // writes while the other side is closing can cause EPIPE
+        // just wait for close to actually happen and ignore it.
+        if (error && "code" in error && error.code === "EPIPE") {
+          return;
+        }
+        onClose(error);
+      });
+
+      return [data => writeStream.write(data), () => writeStream.end()];
+    }),
   });
 }
 
@@ -17,11 +49,11 @@ function streamsForPipe(child: import("execa").ExecaChildProcess) {
   const stdio: unknown[] = child.stdio;
   if (stdio.length === 5) {
     return stdio as [
-      NodeJS.WriteStream,
-      NodeJS.ReadStream,
-      NodeJS.ReadStream,
-      NodeJS.WriteStream,
-      NodeJS.ReadStream
+      NodeJS.WritableStream,
+      NodeJS.ReadableStream,
+      NodeJS.ReadableStream,
+      NodeJS.WritableStream,
+      NodeJS.ReadableStream,
     ];
   }
   throw new Error("expected process to have 5 stdio streams");

--- a/chrome-debugging-client/src/index.ts
+++ b/chrome-debugging-client/src/index.ts
@@ -46,15 +46,19 @@ export async function spawnWithWebSocket(
     url,
     combineRaceCancellation(process.raceExit, raceCancellation),
   );
-  const connection = newProtocolConnection(attach);
+  const connection = newProtocolConnection(attach, process.raceExit);
   return Object.assign(process, { connection, close });
 }
 
-export function newProtocolConnection(attach: AttachMessageTransport) {
+export function newProtocolConnection(
+  attach: AttachMessageTransport,
+  raceCancellation?: RaceCancellation,
+) {
   return _newProtocolConnection(
     attach,
     () => new EventEmitter(),
     debugCallback,
+    raceCancellation,
   );
 }
 
@@ -70,7 +74,7 @@ function attachPipeTransport<P extends ProcessWithPipeMessageTransport>(
   connection: RootConnection;
   close(timeout?: number, raceCancellation?: RaceCancellation): Promise<void>;
 } {
-  const connection = newProtocolConnection(process.attach);
+  const connection = newProtocolConnection(process.attach, process.raceExit);
   return Object.assign(process, { close, connection });
 
   async function close(timeout?: number, raceCancellation?: RaceCancellation) {

--- a/test/spawnChromeTest.js
+++ b/test/spawnChromeTest.js
@@ -65,4 +65,28 @@ QUnit.module("spawnChrome", () => {
       }
     },
   );
+
+  QUnit.test("spawn chrome at bad path", async assert => {
+    const chrome = spawnChrome({
+      chromeExecutable: "bad/path/to/chrome",
+      headless: true,
+    });
+    try {
+      const browser = chrome.connection;
+
+      try {
+        await browser.send("Browser.getVersion");
+        assert.ok(false, "should not get here");
+      } catch (e) {
+        assert.equal(
+          e.message,
+          "process exited early: spawn bad/path/to/chrome ENOENT",
+        );
+      }
+
+      assert.ok(chrome.hasExited());
+    } finally {
+      await chrome.dispose();
+    }
+  });
 });


### PR DESCRIPTION
Ensure raceExit gets entangled with message transport.
Handle exit event may not get called on error, on more than once.
Fix stdio option getting passed through.
Fix raceCancellation getting threaded through some client methods.
Ignore EPIPE on write errors.