### PR TITLE
refactor(debug): Debug logging cleanup.

### DIFF
--- a/@tracerbench/spawn-chrome/src/spawnChrome.ts
+++ b/@tracerbench/spawn-chrome/src/spawnChrome.ts
@@ -1,5 +1,5 @@
 import findChrome from "@tracerbench/find-chrome";
-import spawn from "@tracerbench/spawn";
+import spawn, { DebugCallback } from "@tracerbench/spawn";
 
 import { Chrome, SpawnOptions } from "../types";
 
@@ -7,7 +7,10 @@ import canonicalizeOptions from "./canonicalizeOptions";
 import createTempDir from "./createTmpDir";
 import getArguments from "./getArguments";
 
-export default function spawnChrome(options?: Partial<SpawnOptions>): Chrome {
+export default function spawnChrome(
+  options?: Partial<SpawnOptions>,
+  debugCallback?: DebugCallback,
+): Chrome {
   const canonicalized = canonicalizeOptions(options);
 
   let chromeExecutable = canonicalized.chromeExecutable;
@@ -24,7 +27,7 @@ export default function spawnChrome(options?: Partial<SpawnOptions>): Chrome {
   const args = getArguments(userDataDir, canonicalized);
 
   const process = Object.assign(
-    spawn(chromeExecutable, args, canonicalized.stdio, "pipe"),
+    spawn(chromeExecutable, args, canonicalized.stdio, "pipe", debugCallback),
     {
       userDataDir,
     },

--- a/@tracerbench/spawn/src/spawn.ts
+++ b/@tracerbench/spawn/src/spawn.ts
@@ -1,39 +1,52 @@
 import debug from "debug";
 
-import * as t from "../types";
+import {
+  DebugCallback,
+  ProcessWithPipeMessageTransport,
+  ProcessWithWebSocketUrl,
+  Stdio,
+  Transport,
+} from "../types";
 
 import newProcessWithPipeMessageTransport from "./newProcessWithPipeMessageTransport";
 import newProcessWithWebSocketUrl from "./newProcessWithWebSocketUrl";
 
-const debugCallback = debug("@tracerbench/spawn");
-
-export default function spawn<T extends t.Transport>(
-  executable: string,
-  args: string[],
-  stdio: t.Stdio | undefined,
-  transport: T,
-): t.TransportMapping[T];
-export default function spawn<T extends t.Transport>(
-  executable: string,
-  args: string[],
-  stdio?: t.Stdio,
-): t.ProcessWithPipeMessageTransport;
 export default function spawn(
   executable: string,
   args: string[],
-  stdio: t.Stdio = "ignore",
-  transport: t.Transport = "pipe",
-): t.TransportMapping[t.Transport] {
+  stderr: Stdio | undefined,
+  transport: "websocket",
+  debugCallback?: DebugCallback,
+): ProcessWithWebSocketUrl;
+export default function spawn(
+  executable: string,
+  args: string[],
+  stderr?: Stdio,
+  transport?: "pipe",
+  debugCallback?: DebugCallback,
+): ProcessWithPipeMessageTransport;
+export default function spawn(
+  executable: string,
+  args: string[],
+  stderr: Stdio = "ignore",
+  transport: Transport = "pipe",
+  debugCallback: DebugCallback = debug("@tracerbench/spawn"),
+): ProcessWithPipeMessageTransport | ProcessWithWebSocketUrl {
   switch (transport) {
     case "pipe":
       return newProcessWithPipeMessageTransport(
         executable,
         args,
-        stdio,
+        stderr,
         debugCallback,
       );
     case "websocket":
-      return newProcessWithWebSocketUrl(executable, args, stdio, debugCallback);
+      return newProcessWithWebSocketUrl(
+        executable,
+        args,
+        stderr,
+        debugCallback,
+      );
     default:
       throw invalidTransport(transport);
   }

--- a/@tracerbench/spawn/types.d.ts
+++ b/@tracerbench/spawn/types.d.ts
@@ -1,6 +1,8 @@
 import { AttachMessageTransport } from "@tracerbench/message-transport";
 import { RaceCancellation } from "race-cancellation";
 
+export type DebugCallback = (formatter: any, ...args: any[]) => void;
+
 export interface Process {
   /**
    * Allows tasks to be raced against the exit of the process.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ designed with automation in mind.
     attaching flattened session connections to targets.
 -   Supports cancellation in a way that avoids unhandled rejections, and allows you to add combine
     additional cancellation concerns.
--   Supports seeing protocol debug messages with `DEBUG=chrome-debugging-client`
+-   Supports seeing protocol debug messages with `DEBUG=chrome-debugging-client:*`
 -   Use with race-cancellation library to add timeouts or other cancellation concerns to tasks
     using the connection.
 -   The library was designed to be careful about not floating promises (promises are

--- a/chrome-debugging-client/README.md
+++ b/chrome-debugging-client/README.md
@@ -26,7 +26,7 @@ designed with automation in mind.
     attaching flattened session connections to targets.
 -   Supports cancellation in a way that avoids unhandled rejections, and allows you to add combine
     additional cancellation concerns.
--   Supports seeing protocol debug messages with `DEBUG=chrome-debugging-client`
+-   Supports seeing protocol debug messages with `DEBUG=chrome-debugging-client:*`
 -   Use with race-cancellation library to add timeouts or other cancellation concerns to tasks
     using the connection.
 -   The library was designed to be careful about not floating promises (promises are

--- a/chrome-debugging-client/src/index.ts
+++ b/chrome-debugging-client/src/index.ts
@@ -13,7 +13,8 @@ import debug = require("debug");
 import { EventEmitter } from "events";
 import { combineRaceCancellation, RaceCancellation } from "race-cancellation";
 
-const debugCallback = debug("chrome-debugging-client");
+const debugSpawn = debug("chrome-debugging-client:spawn");
+const debugTransport = debug("chrome-debugging-client:transport");
 
 export * from "@tracerbench/message-transport";
 export * from "@tracerbench/protocol-connection/types";
@@ -23,7 +24,7 @@ export * from "@tracerbench/spawn-chrome/types";
 export function spawnChrome(
   options?: Partial<SpawnOptions>,
 ): ChromeWithPipeConnection {
-  return attachPipeTransport(_spawnChrome(options));
+  return attachPipeTransport(_spawnChrome(options, debugSpawn));
 }
 
 export function spawnWithPipe(
@@ -31,7 +32,9 @@ export function spawnWithPipe(
   args: string[],
   stdio?: Stdio,
 ): ProcessWithPipeConnection {
-  return attachPipeTransport(_spawn(executable, args, stdio, "pipe"));
+  return attachPipeTransport(
+    _spawn(executable, args, stdio, "pipe", debugSpawn),
+  );
 }
 
 export async function spawnWithWebSocket(
@@ -40,7 +43,7 @@ export async function spawnWithWebSocket(
   stdio?: Stdio,
   raceCancellation?: RaceCancellation,
 ): Promise<ProcessWithWebSocketConnection> {
-  const process = _spawn(executable, args, stdio, "websocket");
+  const process = _spawn(executable, args, stdio, "websocket", debugSpawn);
   const url = await process.url(raceCancellation);
   const [attach, close] = await openWebSocket(
     url,
@@ -57,7 +60,7 @@ export function newProtocolConnection(
   return _newProtocolConnection(
     attach,
     () => new EventEmitter(),
-    debugCallback,
+    debugTransport,
     raceCancellation,
   );
 }


### PR DESCRIPTION
Allow chrome-debugging-client to pass in a debug callback.

`@tracerbench/spawn` becomes `chrome-debugging-client:spawn`
`chrome-debugging-client` becomes `chrome-debugging-client:transport`
