### PR TITLE
feat: add more spawn options

### DIFF
--- a/@tracerbench/message-transport/package.json
+++ b/@tracerbench/message-transport/package.json
@@ -7,6 +7,7 @@
     "index.d.ts"
   ],
   "types": "index.d.ts",
+  "main": "index.js",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",

--- a/@tracerbench/protocol-connection/src/index.ts
+++ b/@tracerbench/protocol-connection/src/index.ts
@@ -1,10 +1,12 @@
-import type { AttachMessageTransport } from "@tracerbench/message-transport";
-import newAttachProtocolTransport, {
-  DebugCallback,
-} from "@tracerbench/protocol-transport";
-import type { RaceCancellation } from "race-cancellation";
+import newAttachProtocolTransport from "@tracerbench/protocol-transport";
 
-import type { EventEmitter, RootConnection } from "../types";
+import type {
+  AttachMessageTransport,
+  DebugCallback,
+  EventEmitter,
+  RaceCancellation,
+  RootConnection,
+} from "../types";
 import _newProtocolConnection from "./newProtocolConnection";
 
 /**
@@ -24,6 +26,33 @@ export default function newProtocolConnection(
 
 export { default as newProtocolConnection } from "./newProtocolConnection";
 export type {
+  AttachJsonRpcTransport,
+  AttachMessageTransport,
+  AttachProtocolTransport,
+  AttachSession,
+  Cancellation,
+  DebugCallback,
+  DetachSession,
+  ErrorResponse,
+  Notification,
+  OnClose,
+  OnError,
+  OnEvent,
+  OnMessage,
+  OnNotification,
+  Protocol,
+  ProtocolMapping,
+  ProtocolError,
+  ProtocolTransport,
+  RaceCancellation,
+  Request,
+  Response,
+  ResponseError,
+  SendMessage,
+  SendMethod,
+  SendRequest,
+  SuccessResponse,
+  Task,
   ProtocolConnection,
   SessionConnection,
   RootConnection,

--- a/@tracerbench/protocol-connection/src/newEventHook.ts
+++ b/@tracerbench/protocol-connection/src/newEventHook.ts
@@ -1,6 +1,5 @@
-import Protocol from "devtools-protocol";
-
 import type {
+  Protocol,
   SessionConnection,
   SessionID,
   SessionIdentifier,

--- a/@tracerbench/protocol-connection/src/newProtocolConnection.ts
+++ b/@tracerbench/protocol-connection/src/newProtocolConnection.ts
@@ -1,24 +1,23 @@
 import {
-  AttachProtocolTransport,
-  AttachSession,
-} from "@tracerbench/protocol-transport";
-import Protocol from "devtools-protocol";
-import {
   combineRaceCancellation,
   disposablePromise,
-  RaceCancellation,
   throwIfCancelled,
 } from "race-cancellation";
 
-import {
+import type {
+  AttachProtocolTransport,
+  AttachSession,
   NewEventEmitter,
+  Protocol,
   ProtocolConnection,
+  RaceCancellation,
   RootConnection,
   SessionConnection,
   SessionID,
   TargetID,
 } from "../types";
-import newEventHook, { Session } from "./newEventHook";
+import type { Session } from "./newEventHook";
+import newEventHook from "./newEventHook";
 
 /**
  * This method adapts a AttachProtocolTransport into higher level

--- a/@tracerbench/protocol-connection/types.d.ts
+++ b/@tracerbench/protocol-connection/types.d.ts
@@ -1,6 +1,62 @@
-import Protocol from "devtools-protocol";
-import { ProtocolMapping } from "devtools-protocol/types/protocol-mapping";
-import { RaceCancellation } from "race-cancellation";
+import type {
+  AttachJsonRpcTransport,
+  AttachMessageTransport,
+  AttachProtocolTransport,
+  AttachSession,
+  Cancellation,
+  DebugCallback,
+  DetachSession,
+  ErrorResponse,
+  Notification,
+  OnClose,
+  OnError,
+  OnEvent,
+  OnMessage,
+  OnNotification,
+  ProtocolError,
+  ProtocolTransport,
+  RaceCancellation,
+  Request,
+  Response,
+  ResponseError,
+  SendMessage,
+  SendMethod,
+  SendRequest,
+  SuccessResponse,
+  Task,
+} from "@tracerbench/protocol-transport";
+import type { Protocol } from "devtools-protocol";
+import type { ProtocolMapping } from "devtools-protocol/types/protocol-mapping";
+
+export type {
+  AttachJsonRpcTransport,
+  AttachMessageTransport,
+  AttachProtocolTransport,
+  AttachSession,
+  Cancellation,
+  DebugCallback,
+  DetachSession,
+  ErrorResponse,
+  Notification,
+  OnClose,
+  OnError,
+  OnEvent,
+  OnMessage,
+  OnNotification,
+  Protocol,
+  ProtocolMapping,
+  ProtocolError,
+  ProtocolTransport,
+  RaceCancellation,
+  Request,
+  Response,
+  ResponseError,
+  SendMessage,
+  SendMethod,
+  SendRequest,
+  SuccessResponse,
+  Task,
+};
 
 export type ProtocolConnection = SessionConnection | RootConnection;
 

--- a/@tracerbench/protocol-transport/src/index.ts
+++ b/@tracerbench/protocol-transport/src/index.ts
@@ -1,7 +1,9 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
-import { RaceCancellation } from "race-cancellation";
-
-import { AttachProtocolTransport, DebugCallback } from "../types";
+import type {
+  AttachMessageTransport,
+  AttachProtocolTransport,
+  DebugCallback,
+  RaceCancellation,
+} from "../types";
 import newAttachJsonRpcTransport from "./newAttachJsonRpcTransport";
 import _newAttachProtocolTransport from "./newAttachProtocolTransport";
 
@@ -19,6 +21,13 @@ export { default as newAttachJsonRpcTransport } from "./newAttachJsonRpcTranspor
 export { default as newAttachProtocolTransport } from "./newAttachProtocolTransport";
 export { isProtocolError } from "./newProtocolError";
 export type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+  Cancellation,
+  RaceCancellation,
+  Task,
   AttachJsonRpcTransport,
   SendRequest,
   AttachProtocolTransport,
@@ -36,6 +45,5 @@ export type {
   ProtocolError,
   OnNotification,
   OnError,
-  OnClose,
   OnEvent,
 } from "../types";

--- a/@tracerbench/protocol-transport/src/newAttachJsonRpcTransport.ts
+++ b/@tracerbench/protocol-transport/src/newAttachJsonRpcTransport.ts
@@ -1,15 +1,15 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
 import {
   cancellableRace,
   combineRaceCancellation,
-  RaceCancellation,
   throwIfCancelled,
 } from "race-cancellation";
 
-import {
+import type {
   AttachJsonRpcTransport,
+  AttachMessageTransport,
   DebugCallback,
   Notification,
+  RaceCancellation,
   Request,
   Response,
 } from "../types";

--- a/@tracerbench/protocol-transport/src/newAttachProtocolTransport.ts
+++ b/@tracerbench/protocol-transport/src/newAttachProtocolTransport.ts
@@ -1,9 +1,8 @@
-import { RaceCancellation } from "race-cancellation";
-
-import {
+import type {
   AttachJsonRpcTransport,
   AttachProtocolTransport,
   Notification,
+  RaceCancellation,
 } from "../types";
 import newProtocolError from "./newProtocolError";
 import newSessions from "./newSessions";

--- a/@tracerbench/protocol-transport/src/newProtocolError.ts
+++ b/@tracerbench/protocol-transport/src/newProtocolError.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse, ProtocolError, Request } from "../types";
+import type { ErrorResponse, ProtocolError, Request } from "../types";
 
 export default function newProtocolError(
   request: Request,

--- a/@tracerbench/protocol-transport/src/newResponses.ts
+++ b/@tracerbench/protocol-transport/src/newResponses.ts
@@ -1,6 +1,7 @@
-import { Complete, oneshot } from "race-cancellation";
+import type { Complete } from "race-cancellation";
+import { oneshot } from "race-cancellation";
 
-import { Response } from "../types";
+import type { Response } from "../types";
 
 export default function newResponses(): [UsingResponse, ResolveResponse] {
   let seq = 0;

--- a/@tracerbench/protocol-transport/src/newSessions.ts
+++ b/@tracerbench/protocol-transport/src/newSessions.ts
@@ -1,13 +1,10 @@
-import {
-  cancellableRace,
-  combineRaceCancellation,
-  RaceCancellation,
-} from "race-cancellation";
+import { cancellableRace, combineRaceCancellation } from "race-cancellation";
 
 import {
   AttachProtocolTransport,
   AttachSession,
   DetachSession,
+  RaceCancellation,
 } from "../types";
 
 export type DispatchEvent<SessionId> = (

--- a/@tracerbench/protocol-transport/types.d.ts
+++ b/@tracerbench/protocol-transport/types.d.ts
@@ -1,4 +1,20 @@
-import { RaceCancellation } from "race-cancellation";
+import {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+} from "@tracerbench/message-transport";
+import { Cancellation, RaceCancellation, Task } from "race-cancellation";
+
+export type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+  Cancellation,
+  RaceCancellation,
+  Task,
+};
 
 export type AttachJsonRpcTransport = (
   onNotification: OnNotification,
@@ -92,7 +108,7 @@ export interface Notification<
   sessionId?: SessionID;
 }
 
-export type DebugCallback = (fmt: string, ...args: any[]) => void;
+export type DebugCallback = (formatter: unknown, ...args: unknown[]) => void;
 
 export interface ProtocolError<
   Method extends string = string,
@@ -110,7 +126,6 @@ export type OnNotification = <
   notification: Notification<Method, Params>,
 ) => void;
 export type OnError = (error: Error) => void;
-export type OnClose = () => void;
 export type OnEvent = <
   Event extends string = string,
   Params extends object = object

--- a/@tracerbench/spawn-chrome/src/canonicalizeOptions.ts
+++ b/@tracerbench/spawn-chrome/src/canonicalizeOptions.ts
@@ -1,9 +1,9 @@
-import { SpawnOptions } from "../types";
+import type { ChromeSpawnOptions } from "../types";
 
 const CANONICALIZE: {
-  [K in keyof SpawnOptions]: Canonicalize<SpawnOptions[K]>;
+  [K in keyof ChromeSpawnOptions]: Canonicalize<ChromeSpawnOptions[K]>;
 } & {
-  [key: string]: Canonicalize<SpawnOptions[keyof SpawnOptions]>;
+  [key: string]: Canonicalize<ChromeSpawnOptions[keyof ChromeSpawnOptions]>;
 } = {
   additionalArguments: arrayOf("string"),
   chromeExecutable: primitive("string"),
@@ -13,6 +13,9 @@ const CANONICALIZE: {
   url: primitive("string"),
   userDataDir: primitive("string"),
   userDataRoot: primitive("string"),
+  cwd: primitive("string"),
+  extendEnv: primitive("boolean"),
+  env: env(),
 };
 
 type Canonicalize<T> = (value: unknown, key: string) => T;
@@ -62,9 +65,20 @@ function arrayOf<T extends keyof PrimitiveMapping>(
   };
 }
 
-export default function canonicalizeOptions(options: unknown): SpawnOptions {
-  const canonical: SpawnOptions & {
-    [key: string]: SpawnOptions[keyof SpawnOptions];
+function env(): Canonicalize<{ [name: string]: string | undefined }> {
+  return (value, key) => {
+    if (isObject(value)) {
+      return value as { [name: string]: string | undefined };
+    }
+    return invalidOption(key, "env");
+  };
+}
+
+export default function canonicalizeOptions(
+  options: unknown,
+): ChromeSpawnOptions {
+  const canonical: ChromeSpawnOptions & {
+    [key: string]: ChromeSpawnOptions[keyof ChromeSpawnOptions];
   } = {
     additionalArguments: undefined,
     chromeExecutable: undefined,
@@ -74,6 +88,9 @@ export default function canonicalizeOptions(options: unknown): SpawnOptions {
     url: undefined,
     userDataDir: undefined,
     userDataRoot: undefined,
+    cwd: undefined,
+    extendEnv: undefined,
+    env: undefined,
   };
 
   if (isObject(options)) {

--- a/@tracerbench/spawn-chrome/src/getArguments.ts
+++ b/@tracerbench/spawn-chrome/src/getArguments.ts
@@ -1,4 +1,4 @@
-import { ArgumentOptions } from "../types";
+import type { ArgumentOptions } from "../types";
 import defaultFlags, { headlessFlags } from "./defaultFlags";
 
 export default function getArguments(

--- a/@tracerbench/spawn-chrome/src/index.ts
+++ b/@tracerbench/spawn-chrome/src/index.ts
@@ -1,4 +1,23 @@
-export type { ArgumentOptions, SpawnOptions, Chrome } from "../types";
+export type {
+  AttachMessageTransport,
+  Cancellation,
+  DebugCallback,
+  OnClose,
+  OnMessage,
+  Process,
+  ProcessWithPipeMessageTransport,
+  ProcessWithWebSocketUrl,
+  RaceCancellation,
+  SendMessage,
+  SpawnOptions,
+  Stdio,
+  Task,
+  Transport,
+  TransportMapping,
+  ArgumentOptions,
+  ChromeSpawnOptions,
+  Chrome,
+} from "../types";
 export { default } from "./spawnChrome";
 export { defaultFlags, headlessFlags } from "./defaultFlags";
 export { default as getArguments } from "./getArguments";

--- a/@tracerbench/spawn-chrome/src/spawnChrome.ts
+++ b/@tracerbench/spawn-chrome/src/spawnChrome.ts
@@ -1,13 +1,13 @@
 import findChrome from "@tracerbench/find-chrome";
-import spawn, { DebugCallback } from "@tracerbench/spawn";
+import spawn from "@tracerbench/spawn";
 
-import { Chrome, SpawnOptions } from "../types";
+import type { Chrome, ChromeSpawnOptions, DebugCallback } from "../types";
 import canonicalizeOptions from "./canonicalizeOptions";
 import createTempDir from "./createTmpDir";
 import getArguments from "./getArguments";
 
 export default function spawnChrome(
-  options?: Partial<SpawnOptions>,
+  options?: Partial<ChromeSpawnOptions>,
   debugCallback?: DebugCallback,
 ): Chrome {
   const canonicalized = canonicalizeOptions(options);
@@ -40,7 +40,7 @@ export default function spawnChrome(
   const args = getArguments(userDataDir, canonicalized);
 
   const chromeProcess = Object.assign(
-    spawn(chromeExecutable, args, canonicalized.stdio, "pipe", debugCallback),
+    spawn(chromeExecutable, args, canonicalized, "pipe", debugCallback),
     {
       userDataDir,
     },

--- a/@tracerbench/spawn-chrome/types.d.ts
+++ b/@tracerbench/spawn-chrome/types.d.ts
@@ -1,4 +1,38 @@
-import { ProcessWithPipeMessageTransport, Stdio } from "@tracerbench/spawn";
+import type {
+  AttachMessageTransport,
+  Cancellation,
+  DebugCallback,
+  OnClose,
+  OnMessage,
+  Process,
+  ProcessWithPipeMessageTransport,
+  ProcessWithWebSocketUrl,
+  RaceCancellation,
+  SendMessage,
+  SpawnOptions,
+  Stdio,
+  Task,
+  Transport,
+  TransportMapping,
+} from "@tracerbench/spawn";
+
+export type {
+  AttachMessageTransport,
+  Cancellation,
+  DebugCallback,
+  OnClose,
+  OnMessage,
+  Process,
+  ProcessWithPipeMessageTransport,
+  ProcessWithWebSocketUrl,
+  RaceCancellation,
+  SendMessage,
+  SpawnOptions,
+  Stdio,
+  Task,
+  Transport,
+  TransportMapping,
+};
 
 export interface ArgumentOptions {
   /**
@@ -24,12 +58,7 @@ export interface ArgumentOptions {
   headless: boolean;
 }
 
-export interface SpawnOptions extends ArgumentOptions {
-  /**
-   * Whether the stdio output should be inherited or ignored.
-   */
-  stdio: Stdio;
-
+export interface ChromeSpawnOptions extends ArgumentOptions, SpawnOptions {
   /**
    * Override finding the chrome executable.
    */

--- a/@tracerbench/spawn/src/index.ts
+++ b/@tracerbench/spawn/src/index.ts
@@ -1,10 +1,18 @@
 export { default } from "./spawn";
 export type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+  Cancellation,
+  RaceCancellation,
+  Task,
   DebugCallback,
   Process,
-  ProcessWithPipeMessageTransport,
   ProcessWithWebSocketUrl,
-  Stdio,
+  ProcessWithPipeMessageTransport,
   TransportMapping,
   Transport,
+  Stdio,
+  SpawnOptions,
 } from "../types";

--- a/@tracerbench/spawn/src/newPipeMessageTransport.ts
+++ b/@tracerbench/spawn/src/newPipeMessageTransport.ts
@@ -1,5 +1,4 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
-
+import type { AttachMessageTransport } from "../types";
 import newBufferSplitter from "./newBufferSplitter";
 import newTaskQueue from "./newTaskQueue";
 

--- a/@tracerbench/spawn/src/newProcess.ts
+++ b/@tracerbench/spawn/src/newProcess.ts
@@ -1,20 +1,24 @@
 import { EventEmitter } from "events";
+import type { ExecaChildProcess } from "execa";
 import {
   cancellableRace,
-  Cancellation,
   disposablePromise,
-  RaceCancellation,
   throwIfCancelled,
   withRaceTimeout,
 } from "race-cancellation";
 
-import * as t from "../types";
+import type {
+  Cancellation,
+  DebugCallback,
+  Process,
+  RaceCancellation,
+} from "../types";
 
 export default function newProcess(
-  child: import("execa").ExecaChildProcess,
+  child: ExecaChildProcess,
   command: string,
-  debugCallback: (formatter: unknown, ...args: unknown[]) => void,
-): t.Process {
+  debugCallback: DebugCallback,
+): Process {
   let hasExited = false;
   let lastError: Error | undefined;
 

--- a/@tracerbench/spawn/src/newProcessWithPipeMessageTransport.ts
+++ b/@tracerbench/spawn/src/newProcessWithPipeMessageTransport.ts
@@ -1,4 +1,4 @@
-import { ProcessWithPipeMessageTransport, Stdio } from "../types";
+import type { ProcessWithPipeMessageTransport, SpawnOptions } from "../types";
 import execa from "./execa";
 import createPipeMessageTransport from "./newPipeMessageTransport";
 import newProcess from "./newProcess";
@@ -6,9 +6,10 @@ import newProcess from "./newProcess";
 export default function newProcessWithPipeMessageTransport(
   command: string,
   args: string[],
-  stdio: Stdio,
+  options: Partial<SpawnOptions>,
   debugCallback: (formatter: unknown, ...args: unknown[]) => void,
 ): ProcessWithPipeMessageTransport {
+  const { stdio = "ignore", cwd, env, extendEnv } = options;
   const child = execa(
     command,
     args,
@@ -16,6 +17,9 @@ export default function newProcessWithPipeMessageTransport(
       // disable buffer, pipe or drain
       buffer: false,
       stdio: [stdio, stdio, stdio, "pipe", "pipe"],
+      cwd,
+      extendEnv,
+      env,
     },
     debugCallback,
   );

--- a/@tracerbench/spawn/src/newProcessWithWebSocketUrl.ts
+++ b/@tracerbench/spawn/src/newProcessWithWebSocketUrl.ts
@@ -4,7 +4,7 @@ import {
   throwIfCancelled,
 } from "race-cancellation";
 
-import { ProcessWithWebSocketUrl, Stdio } from "../types";
+import type { ProcessWithWebSocketUrl, SpawnOptions, Stdio } from "../types";
 import execa from "./execa";
 import newProcess from "./newProcess";
 import newWebSocketUrlParser from "./newWebSocketUrlParser";
@@ -12,9 +12,10 @@ import newWebSocketUrlParser from "./newWebSocketUrlParser";
 export default function newProcessWithWebSocketUrl(
   command: string,
   args: string[],
-  stdio: Stdio,
+  options: Partial<SpawnOptions>,
   debugCallback: (formatter: unknown, ...args: unknown[]) => void,
 ): ProcessWithWebSocketUrl {
+  const { stdio = "ignore", cwd, env, extendEnv } = options;
   const child = execa(
     command,
     args,
@@ -22,6 +23,9 @@ export default function newProcessWithWebSocketUrl(
       // disable buffer, pipe or drain
       buffer: false,
       stdio: [stdio, stdio, "pipe"],
+      cwd,
+      extendEnv,
+      env,
     },
     debugCallback,
   );
@@ -60,7 +64,7 @@ function createUrl(
 
 function parseUrl(
   stderr: NodeJS.ReadableStream,
-  stdio: "inherit" | "ignore",
+  stdio: Stdio,
   callback: (url: string) => void,
 ): void {
   const parser = newWebSocketUrlParser(callback);

--- a/@tracerbench/spawn/src/newWebSocketUrlParser.ts
+++ b/@tracerbench/spawn/src/newWebSocketUrlParser.ts
@@ -1,4 +1,5 @@
-import { Transform, TransformCallback } from "stream";
+import type { TransformCallback } from "stream";
+import { Transform } from "stream";
 
 import newBufferSplitter from "./newBufferSplitter";
 

--- a/@tracerbench/spawn/src/spawn.ts
+++ b/@tracerbench/spawn/src/spawn.ts
@@ -1,9 +1,10 @@
 import debug from "debug";
 
-import {
+import type {
   DebugCallback,
   ProcessWithPipeMessageTransport,
   ProcessWithWebSocketUrl,
+  SpawnOptions,
   Stdio,
   Transport,
 } from "../types";
@@ -13,37 +14,40 @@ import newProcessWithWebSocketUrl from "./newProcessWithWebSocketUrl";
 function spawn(
   executable: string,
   args: string[],
-  stderr: Stdio | undefined,
+  options: Stdio | Partial<SpawnOptions> | undefined,
   transport: "websocket",
   debugCallback?: DebugCallback,
 ): ProcessWithWebSocketUrl;
 function spawn(
   executable: string,
   args: string[],
-  stderr?: Stdio,
+  options?: Stdio | Partial<SpawnOptions>,
   transport?: "pipe",
   debugCallback?: DebugCallback,
 ): ProcessWithPipeMessageTransport;
 function spawn(
   executable: string,
   args: string[],
-  stderr: Stdio = "ignore",
+  options: Stdio | Partial<SpawnOptions> = { stdio: "ignore" },
   transport: Transport = "pipe",
   debugCallback: DebugCallback = debug("@tracerbench/spawn"),
 ): ProcessWithPipeMessageTransport | ProcessWithWebSocketUrl {
+  if (typeof options === "string") {
+    options = { stdio: options };
+  }
   switch (transport) {
     case "pipe":
       return newProcessWithPipeMessageTransport(
         executable,
         args,
-        stderr,
+        options,
         debugCallback,
       );
     case "websocket":
       return newProcessWithWebSocketUrl(
         executable,
         args,
-        stderr,
+        options,
         debugCallback,
       );
     default:

--- a/@tracerbench/spawn/types.d.ts
+++ b/@tracerbench/spawn/types.d.ts
@@ -1,7 +1,22 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
-import { RaceCancellation } from "race-cancellation";
+import type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+} from "@tracerbench/message-transport";
+import type { Cancellation, RaceCancellation, Task } from "race-cancellation";
 
-export type DebugCallback = (formatter: any, ...args: any[]) => void;
+export type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+  Cancellation,
+  RaceCancellation,
+  Task,
+};
+
+export type DebugCallback = (formatter: unknown, ...args: unknown[]) => void;
 
 export interface Process {
   /**
@@ -60,3 +75,14 @@ export type TransportMapping = {
 export type Transport = keyof TransportMapping;
 
 export type Stdio = "ignore" | "inherit";
+
+export interface SpawnOptions {
+  stdio: Stdio;
+  cwd: string | undefined;
+  extendEnv: boolean | undefined;
+  env:
+    | {
+        [name: string]: string | undefined;
+      }
+    | undefined;
+}

--- a/@tracerbench/websocket-message-transport/src/index.ts
+++ b/@tracerbench/websocket-message-transport/src/index.ts
@@ -1,7 +1,22 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
-import { disposablePromise, RaceCancellation } from "race-cancellation";
+import type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+} from "@tracerbench/message-transport";
+import type { Cancellation, RaceCancellation, Task } from "race-cancellation";
+import { disposablePromise } from "race-cancellation";
 import NodeWebSocket = require("ws");
 
+export type {
+  AttachMessageTransport,
+  OnClose,
+  OnMessage,
+  SendMessage,
+  Cancellation,
+  RaceCancellation,
+  Task,
+};
 export type CloseWebSocket = () => void;
 
 export default async function openWebSocket(

--- a/chrome-debugging-client/src/index.ts
+++ b/chrome-debugging-client/src/index.ts
@@ -1,76 +1,28 @@
-import { AttachMessageTransport } from "@tracerbench/message-transport";
-import _newProtocolConnection, {
+import type {
+  AttachMessageTransport,
   RootConnection,
 } from "@tracerbench/protocol-connection";
-import _spawn, {
+import _newProtocolConnection from "@tracerbench/protocol-connection";
+import _spawn from "@tracerbench/spawn";
+import type {
+  Chrome,
+  ChromeSpawnOptions,
   Process,
   ProcessWithPipeMessageTransport,
   Stdio,
-} from "@tracerbench/spawn";
-import _spawnChrome, { Chrome, SpawnOptions } from "@tracerbench/spawn-chrome";
+} from "@tracerbench/spawn-chrome";
+import _spawnChrome from "@tracerbench/spawn-chrome";
 import openWebSocket from "@tracerbench/websocket-message-transport";
 import debug = require("debug");
 import { EventEmitter } from "events";
-import {
-  combineRaceCancellation,
-  isCancellation,
-  RaceCancellation,
-} from "race-cancellation";
+import type { RaceCancellation } from "race-cancellation";
+import { combineRaceCancellation, isCancellation } from "race-cancellation";
 
 const debugSpawn = debug("chrome-debugging-client:spawn");
 const debugTransport = debug("chrome-debugging-client:transport");
 
-export type {
-  AttachMessageTransport,
-  OnMessage,
-  OnClose,
-  SendMessage,
-} from "@tracerbench/message-transport";
-export type {
-  ProtocolConnection,
-  RootConnection,
-  SessionConnection,
-  ProtocolConnectionBase,
-  EventListener,
-  EventEmitter,
-  EventPredicate,
-  NewEventEmitter,
-  TargetID,
-  TargetInfo,
-  SessionID,
-  Method,
-  Event,
-  EventMapping,
-  RequestMapping,
-  ResponseMapping,
-  VoidRequestMethod,
-  MappedRequestMethod,
-  MaybeMappedRequestMethod,
-  VoidResponseMethod,
-  MappedResponseMethod,
-  VoidRequestVoidResponseMethod,
-  VoidRequestMappedResponseMethod,
-  VoidEvent,
-  MappedEvent,
-  SessionIdentifier,
-} from "@tracerbench/protocol-connection/types";
-export type {
-  DebugCallback,
-  Process,
-  ProcessWithPipeMessageTransport,
-  ProcessWithWebSocketUrl,
-  Stdio,
-  TransportMapping,
-  Transport,
-} from "@tracerbench/spawn/types";
-export type {
-  ArgumentOptions,
-  SpawnOptions,
-  Chrome,
-} from "@tracerbench/spawn-chrome/types";
-
 export function spawnChrome(
-  options?: Partial<SpawnOptions>,
+  options?: Partial<ChromeSpawnOptions>,
 ): ChromeWithPipeConnection {
   return attachPipeTransport(_spawnChrome(options, debugSpawn));
 }
@@ -78,10 +30,10 @@ export function spawnChrome(
 export function spawnWithPipe(
   executable: string,
   args: string[],
-  stdio?: Stdio,
+  options?: Partial<ChromeSpawnOptions>,
 ): ProcessWithPipeConnection {
   return attachPipeTransport(
-    _spawn(executable, args, stdio, "pipe", debugSpawn),
+    _spawn(executable, args, options, "pipe", debugSpawn),
   );
 }
 
@@ -195,3 +147,71 @@ export interface ProcessWithWebSocketConnection extends Process {
    */
   close(): void;
 }
+
+export type {
+  AttachJsonRpcTransport,
+  AttachMessageTransport,
+  AttachProtocolTransport,
+  AttachSession,
+  Cancellation,
+  DebugCallback,
+  DetachSession,
+  ErrorResponse,
+  Notification,
+  OnClose,
+  OnError,
+  OnEvent,
+  OnMessage,
+  OnNotification,
+  Protocol,
+  ProtocolMapping,
+  ProtocolError,
+  ProtocolTransport,
+  RaceCancellation,
+  Request,
+  Response,
+  ResponseError,
+  SendMessage,
+  SendMethod,
+  SendRequest,
+  SuccessResponse,
+  Task,
+  ProtocolConnection,
+  SessionConnection,
+  RootConnection,
+  ProtocolConnectionBase,
+  EventListener,
+  EventEmitter,
+  EventPredicate,
+  NewEventEmitter,
+  TargetID,
+  TargetInfo,
+  SessionID,
+  Method,
+  Event,
+  EventMapping,
+  RequestMapping,
+  ResponseMapping,
+  VoidRequestMethod,
+  MappedRequestMethod,
+  MaybeMappedRequestMethod,
+  VoidResponseMethod,
+  MappedResponseMethod,
+  VoidRequestVoidResponseMethod,
+  VoidRequestMappedResponseMethod,
+  VoidEvent,
+  MappedEvent,
+  SessionIdentifier,
+} from "@tracerbench/protocol-connection";
+export type {
+  Process,
+  ProcessWithPipeMessageTransport,
+  ProcessWithWebSocketUrl,
+  SpawnOptions,
+  Stdio,
+  Transport,
+  TransportMapping,
+  ArgumentOptions,
+  ChromeSpawnOptions,
+  Chrome,
+} from "@tracerbench/spawn-chrome";


### PR DESCRIPTION
Fixes #58

Also, ensure all types are exported or reexported from index.

This changes type SpawnOptions to ChromeSpawnOptions and added a separate SpawnOptions. This is a breaking change to types but not an API breaking change.
