### PR TITLE
Add Firefox support to regexp

### DIFF
--- a/@tracerbench/spawn/src/newWebSocketUrlParser.ts
+++ b/@tracerbench/spawn/src/newWebSocketUrlParser.ts
@@ -3,7 +3,7 @@ import { Transform } from "stream";
 
 import newBufferSplitter from "./newBufferSplitter";
 
-const WS_URL_REGEX = /^(?:DevTools|Debugger) listening on (ws:\/\/\d+\.\d+\.\d+\.\d+:\d+\/.+$)/;
+const WS_URL_REGEX = /^(?:DevTools|Debugger) listening on (ws:\/\/[^:]+:\d+\/.+$)/;
 
 const enum Char {
   LF = 10,


### PR DESCRIPTION
Firefox nightly supports CDP out of the box, although not everything is implemented (see https://wiki.mozilla.org/Remote). I'm experimenting with connecting to Firefox using this library, and this is a small change in the regexp that's required to connect to FF. For anyone interested in testing: I'm using `spawnWithWebSocket` and passing the Firefox executable with arguments `['--remote-debugging-port=0', '-url=about:blank']`.