### PR TITLE
Update package.json to include the repository

### DIFF
--- a/@tracerbench/find-chrome/package.json
+++ b/@tracerbench/find-chrome/package.json
@@ -8,6 +8,11 @@
     "dist",
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/find-chrome"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/@tracerbench/message-transport/package.json
+++ b/@tracerbench/message-transport/package.json
@@ -6,6 +6,11 @@
   "files": [
     "index.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/message-transport"
+  },
   "types": "index.d.ts",
   "main": "index.js",
   "devDependencies": {

--- a/@tracerbench/protocol-connection/package.json
+++ b/@tracerbench/protocol-connection/package.json
@@ -8,6 +8,11 @@
     "src",
     "types.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/protocol-connection"
+  },
   "main": "dist/index.umd.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/@tracerbench/protocol-transport/package.json
+++ b/@tracerbench/protocol-transport/package.json
@@ -8,6 +8,11 @@
     "src",
     "types.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/protocol-transport"
+  },
   "main": "dist/index.umd.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/@tracerbench/spawn-chrome/package.json
+++ b/@tracerbench/spawn-chrome/package.json
@@ -8,6 +8,11 @@
     "src",
     "types.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/spawn-chrome"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/@tracerbench/spawn/package.json
+++ b/@tracerbench/spawn/package.json
@@ -9,6 +9,11 @@
     "src",
     "types.d.ts"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/spawn"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/@tracerbench/websocket-message-transport/package.json
+++ b/@tracerbench/websocket-message-transport/package.json
@@ -7,6 +7,11 @@
     "dist",
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "@tracerbench/websocket-message-transport"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/chrome-debugging-client/package.json
+++ b/chrome-debugging-client/package.json
@@ -8,6 +8,11 @@
     "dist",
     "src"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TracerBench/chrome-debugging-client.git",
+    "directory": "chrome-debugging-client"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @tracerbench/find-chrome
* @tracerbench/message-transport
* @tracerbench/protocol-connection
* @tracerbench/protocol-transport
* @tracerbench/spawn
* @tracerbench/spawn-chrome
* @tracerbench/websocket-message-transport
* chrome-debugging-client